### PR TITLE
removed -o from fixed args, since .lst are generated anyways

### DIFF
--- a/src/gamsprocess.cpp
+++ b/src/gamsprocess.cpp
@@ -82,7 +82,7 @@ void GamsProcess::execute()
         QStringList paramList = mCommandLineStr.split(QRegExp("\\s+"));
         args.append(paramList);
     }
-    args << "lo=3" << "ide=1" << "er=99" << "errmsg=1" << QString("o=%1.lst").arg(QFileInfo(mInputFile).baseName());
+    args << "lo=3" << "ide=1" << "er=99" << "errmsg=1";
     mProcess.start(nativeAppPath(), args);
 }
 


### PR DESCRIPTION
this PR should fix the issues with spaces in file name under windows