### PR TITLE
Autosavefix

### DIFF
--- a/src/autosavehandler.cpp
+++ b/src/autosavehandler.cpp
@@ -27,7 +27,11 @@ QStringList AutosaveHandler::checkForAutosaveFiles()
             QStringList files = dir.entryList(filters);
             for (auto file : files) {
                 if (file.startsWith(mAutosavedFileMarker)) {
-                    autsaveFiles << path+"/"+file;
+                    QString autosaveFilePath = path+"/"+file;
+                    file.remove(0,2);
+                    QString originalFilePath = path+"/"+file;
+                    QFileInfo origin(originalFilePath);
+                    if (origin.exists()) autsaveFiles << autosaveFilePath;
                 }
             }
         }

--- a/src/autosavehandler.cpp
+++ b/src/autosavehandler.cpp
@@ -31,7 +31,10 @@ QStringList AutosaveHandler::checkForAutosaveFiles()
                     file.remove(0,2);
                     QString originalFilePath = path+"/"+file;
                     QFileInfo origin(originalFilePath);
-                    if (origin.exists()) autsaveFiles << autosaveFilePath;
+                    if (origin.exists())
+                        autsaveFiles << autosaveFilePath;
+                    else
+                        QFile::remove(autosaveFilePath);
                 }
             }
         }

--- a/src/autosavehandler.cpp
+++ b/src/autosavehandler.cpp
@@ -28,7 +28,7 @@ QStringList AutosaveHandler::checkForAutosaveFiles()
             for (auto file : files) {
                 if (file.startsWith(mAutosavedFileMarker)) {
                     QString autosaveFilePath = path+"/"+file;
-                    file.remove(0,2);
+                    file.replace(mAutosavedFileMarker, "");
                     QString originalFilePath = path+"/"+file;
                     QFileInfo origin(originalFilePath);
                     if (origin.exists())


### PR DESCRIPTION
 fixed studio crashing on startup when a file gets deleted  'trnsport.gms' and its autosave version doesn't '$~trnsport.gms'. Now studio checks if original file exists, if not delete the autosave file. 