### PR TITLE
#523: fixed encoding issues for paths and user encoding

### DIFF
--- a/src/abstractprocess.cpp
+++ b/src/abstractprocess.cpp
@@ -81,7 +81,7 @@ void AbstractProcess::readStdChannel(QProcess::ProcessChannel channel)
     while (avail) {
         mOutputMutex.lock();
         mProcess.setReadChannel(channel);
-        emit newStdChannelData(mProcess.readLine());
+        emit newStdChannelData(mProcess.readLine().constData());
         avail = mProcess.bytesAvailable();
         mOutputMutex.unlock();
     }

--- a/src/abstractprocess.h
+++ b/src/abstractprocess.h
@@ -54,7 +54,7 @@ public:
 
 signals:
     void finished(AbstractProcess *process, int exitCode);
-    void newStdChannelData(const QString &data);
+    void newStdChannelData(const QByteArray &data);
     void stateChanged(QProcess::ProcessState newState);
 
 protected slots:

--- a/src/file/projectfilenode.cpp
+++ b/src/file/projectfilenode.cpp
@@ -76,11 +76,13 @@ int ProjectFileNode::codecMib() const
 void ProjectFileNode::setCodecMib(int mib)
 {
     QTextCodec *codec = QTextCodec::codecForMib(mib);
-    if (!codec)
-        EXCEPT() << "TextCodec not found for MIB " << mib;
+    if (!codec) {
+        DEB() << "TextCodec not found for MIB " << mib;
+        return;
+    }
     if (document() && !isReadOnly() && codec != mCodec) {
         document()->setModified();
-        mCodec = codec;
+        setCodec(codec);
     }
 }
 
@@ -632,6 +634,16 @@ void ProjectFileNode::setEditPositions(QVector<QPoint> edPositions)
         }
 
     }
+}
+
+void ProjectFileNode::setCodec(QTextCodec *codec)
+{
+    mCodec = codec;
+}
+
+QTextCodec *ProjectFileNode::codec() const
+{
+    return mCodec;
 }
 
 void ProjectFileNode::modificationChanged(bool modiState)

--- a/src/file/projectfilenode.h
+++ b/src/file/projectfilenode.h
@@ -60,7 +60,7 @@ public:
 
     /// Changes the codec for this file.
     /// \param codec The name of the new codec.
-    void setCodecMib(int mib);
+    virtual void setCodecMib(int mib);
 
     /// The caption of this file, which is its extended display name.
     /// \return The caption of this node.
@@ -144,6 +144,7 @@ public:
     void unbindMarks() { mMarks = nullptr; }
 
     QString tooltip() override;
+    QTextCodec *codec() const;
 
 signals:
     /// Signal is emitted when the file has been modified externally.
@@ -172,6 +173,7 @@ protected:
     QWidgetList& editorList();
     bool eventFilter(QObject *watched, QEvent *event) override;
     bool mouseOverLink();
+    void setCodec(QTextCodec *codec);
 
 private:
     QVector<QPoint> getEditPositions();

--- a/src/file/projectlognode.cpp
+++ b/src/file/projectlognode.cpp
@@ -20,6 +20,8 @@
  */
 #include <QScrollBar>
 #include <QDir>
+#include <QByteArray>
+#include <QTextCodec>
 #include "projectlognode.h"
 #include "exception.h"
 #include "projectgroupnode.h"
@@ -115,12 +117,21 @@ TextMark*ProjectLogNode::firstErrorMark()
     return mMarks->firstErrorMark();
 }
 
-void ProjectLogNode::addProcessData(QString text)
+void ProjectLogNode::addProcessData(const QByteArray &data)
 {
     // TODO(JM) while creating refs to lst-file some parameters may influence the correct row-in-lst:
     //          PS (PageSize), PC (PageContr), PW (PageWidth)
     if (!mDocument)
         EXCEPT() << "no log-document to add process data";
+    QTextCodec::ConverterState convState;
+    QString text(codec()->toUnicode(data.constData(), data.size(), &convState));
+    if (codec()) {
+        text =codec()->toUnicode(data.constData(), data.size(), &convState);
+    }
+    if (!codec() || convState.invalidChars > 0) {
+        QTextCodec* locCodec = QTextCodec::codecForLocale();
+        text = locCodec->toUnicode(data.constData(), data.size(), &convState);
+    }
 
     ExtractionState state = Outside;
     QRegularExpressionMatch match;
@@ -394,6 +405,20 @@ ProjectFileNode *ProjectLogNode::lstNode() const
 void ProjectLogNode::setLstNode(ProjectFileNode *lstNode)
 {
     mLstNode = lstNode;
+}
+
+void ProjectLogNode::setCodecMib(int mib)
+{
+    if (mib == -1) {
+        mCodec = nullptr;
+        return;
+    }
+    QTextCodec *codec = QTextCodec::codecForMib(mib);
+    if (!codec) {
+        DEB() << "TextCodec not found for MIB " << mib;
+        return;
+    }
+    setCodec(codec);
 }
 
 void ProjectLogNode::setJumpToLogEnd(bool state)

--- a/src/file/projectlognode.h
+++ b/src/file/projectlognode.h
@@ -39,9 +39,10 @@ public:
     void setDebugLog(bool debugLog = true) {mDebugLog = debugLog;}
     ProjectFileNode *lstNode() const;
     void setLstNode(ProjectFileNode *lstNode);
+    void setCodecMib(int mib) override;
 
 public slots:
-    void addProcessData(QString text);
+    void addProcessData(const QByteArray &data);
     void setJumpToLogEnd(bool state);
 
 protected:

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1505,6 +1505,13 @@ void MainWindow::execute(QString commandLineStr, ProjectFileNode* gmsFileNode)
         ui->actionShow_System_Log->trigger();
         return;
     }
+    if (gmsFileNode)
+        logProc->setCodecMib(fc->codecMib());
+    else {
+        ProjectFileNode *runNode = group->findFile(gmsFilePath);
+        logProc->setCodecMib(runNode ? runNode->codecMib() : -1);
+    }
+
     QString workDir = gmsFileNode ? QFileInfo(gmsFilePath).path() : group->location();
     logProc->setJumpToLogEnd(true);
 


### PR DESCRIPTION
 fixed encoding issues for paths and user encoding (e.g. chinese) in log and textmarks.

On receiving a line Studio first tries to convert to users encoding on error chars it tries the systems encoding.